### PR TITLE
Fix Flyway Default Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.1](https://github.com/in2workspace/in2-wallet-api/releases/tag/v1.4.0)
+### Added
+- compose.yaml to test the application locally.
+### Fixed
+- Add the `default-schema` property within the application config file to avoid creating flyway_schema_history table in the public schema.
+
 ## [v1.4.0](https://github.com/in2workspace/in2-wallet-api/releases/tag/v1.4.0)
 ### Changed
 - Removed support for Context Broker.
 - Now the application is using database connection for data storage.
-
 
 ## [v1.3.10](https://github.com/in2workspace/in2-wallet-api/releases/tag/v1.3.10)
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'es.in2'
-version = '1.4.0'
+version = '1.4.1'
 
 java {
     sourceCompatibility = '17'

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,27 @@
+services:
+
+  wallet:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      "SPRING_R2DBC_URL": "r2dbc:postgresql://postgresql:5432/demo?schema=wallet"
+      "SPRING_FLYWAY_URL": "jdbc:postgresql://postgresql:5432/demo?schema=wallet"
+    depends_on:
+      - postgresql
+
+  postgresql:
+    image: postgres
+    environment:
+      POSTGRES_DB: demo
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgresql:/var/lib/postgresql/data
+
+volumes:
+  postgresql:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:

--- a/src/main/resources/application-lcl.yml
+++ b/src/main/resources/application-lcl.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,7 +73,7 @@ hashicorp:
     host: localhost
     port: 8201
     scheme: http
-    token: 0000-0000-0000
+    token:
 
 azure:
   app:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     locations: classpath:db/migration
     user: "postgres"
     password: "postgres"
+    default-schema: wallet
 
 logging:
   pattern:
@@ -72,7 +73,7 @@ hashicorp:
     host: localhost
     port: 8201
     scheme: http
-    token:
+    token: 0000-0000-0000
 
 azure:
   app:


### PR DESCRIPTION
New compose.yaml to test the application locally.
Add the `default-schema` property within the application config file to avoid creating flyway_schema_history table in the public schema.